### PR TITLE
feat(multiswebench): add Multi‑SWE‑Bench adapter, runner protocol + stub, rubric, example env, docs, and smoke test

### DIFF
--- a/docs/multiswebench_integration.md
+++ b/docs/multiswebench_integration.md
@@ -1,0 +1,23 @@
+# Multi‑SWE‑Bench Integration
+
+This repository includes a thin adapter for Multi‑SWE‑Bench style program repair tasks.
+
+- Env: `verifiers.envs.MultiSWEEnv`
+- Runner interface: `verifiers.integrations.multiswebench.MultiSWERunner`
+- Stub runner (for CI): `StubRunner` (no external deps)
+- Rubric: `MultiSWERubric` (1.0 pass, 0.0 fail)
+
+Quick usage with stub runner:
+
+```
+uv run vf-eval vf-multi-swe-bench -a '{"task_id":"stub","expected_token":"PASS_FIX"}' -n 1 -r 1
+```
+
+Production usage:
+- Implement a `MultiSWERunner` using the official harness to checkout repos, apply patches, run tests, and return pass/fail.
+- Inject your runner into `vf-multi-swe-bench` or your own environment module.
+- Use `vf-eval` for evaluations and `report_utils` for HTML reports.
+
+Testing:
+- Smoke test: `tests/test_multiswe_env.py` validates end-to-end flow with `mock_openai_client` and `StubRunner`.
+- Run: `uv run pytest -k multiswe -q`.

--- a/environments/vf_multi_swe_bench/README.md
+++ b/environments/vf_multi_swe_bench/README.md
@@ -1,0 +1,10 @@
+# vf-multi-swe-bench
+
+Multi‑SWE‑Bench adapter environment for verifiers. Wraps the `MultiSWEEnv` and
+uses a runner implementation to interact with the Multi‑SWE‑Bench harness.
+
+Quickstart (stub runner):
+
+```
+uv run vf-eval vf-multi-swe-bench -a '{"task_id":"stub-task","expected_token":"PASS_FIX"}' -n 1 -r 1
+```

--- a/environments/vf_multi_swe_bench/pyproject.toml
+++ b/environments/vf_multi_swe_bench/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "vf-multi-swe-bench"
+description = "Multi-SWE-Bench adapter environment for verifiers"
+version = "0.1.0"
+requires-python = ">=3.11,<3.13"
+dependencies = [
+    "verifiers>=0.1.2",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build]
+include = ["vf_multi_swe_bench.py"]

--- a/environments/vf_multi_swe_bench/vf_multi_swe_bench.py
+++ b/environments/vf_multi_swe_bench/vf_multi_swe_bench.py
@@ -1,0 +1,15 @@
+import verifiers as vf
+from verifiers.integrations.multiswebench import StubRunner
+
+
+def load_environment(task_id: str = "stub", expected_token: str = "PASS_FIX", **kwargs) -> vf.Environment:  # noqa: ARG001
+    """Load a Multi‑SWE‑Bench environment.
+
+    Args:
+        task_id: Benchmark task identifier.
+        expected_token: For stub runner only; token that indicates a successful patch.
+    """
+    runner = StubRunner(expected_token=expected_token)
+    env = vf.MultiSWEEnv(runner=runner, task_id=task_id)
+    env.rubric = vf.MultiSWERubric()  # simple pass/fail rubric
+    return env

--- a/tests/test_multiswe_env.py
+++ b/tests/test_multiswe_env.py
@@ -1,0 +1,40 @@
+import verifiers as vf
+from verifiers.integrations.multiswebench import StubRunner
+from datasets import Dataset
+
+
+def test_multiswe_env_smoke_chat(mock_openai_client):
+    # Async client proposes a patch containing the expected token
+    mock_openai_client.add_chat_response(
+        messages=[{"role": "user", "content": "Propose a patch to fix tests."}],
+        response="""--- a/module.py
++++ b/module.py
+@@
+- return 0
++ return 1  # PASS_FIX
+""",
+    )
+    rubric = vf.MultiSWERubric()
+    dataset_dict = {
+        "prompt": [[{"role": "user", "content": "Propose a patch to fix tests."}]],
+        "answer": ["OK"],
+        "info": [{}],
+        "task": ["multiswe-stub"],
+    }
+    ds = Dataset.from_dict(dataset_dict)
+    env = vf.MultiSWEEnv(
+        runner=StubRunner(expected_token="PASS_FIX"),
+        task_id="stub-task",
+        eval_dataset=ds,
+    )
+    env.rubric = rubric
+    results = env.evaluate(
+        client=mock_openai_client,
+        model="dummy-chat",
+        sampling_args={"max_tokens": 128, "temperature": 0.0},
+        num_examples=1,
+        rollouts_per_example=1,
+        max_concurrent=1,
+    )
+    assert len(results.reward) == 1
+    assert results.reward[0] == 1.0

--- a/verifiers/envs/multiswe_env.py
+++ b/verifiers/envs/multiswe_env.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .multiturn_env import MultiTurnEnv
+from ..integrations.multiswebench import MultiSWERunner, PatchStepResult
+from ..types import Messages, State
+
+
+class MultiSWEEnv(MultiTurnEnv):
+    """Environment adapter for Multi‑SWE‑Bench style program repair tasks.
+
+    Each assistant message is interpreted as a proposed patch (e.g., unified
+    diff). The runner applies the patch and runs tests. The resulting
+    observation (test output summary) is appended as a tool message.
+    Completion is signaled by the runner when tests pass or attempts are
+    exhausted.
+    """
+
+    def __init__(
+        self,
+        runner: MultiSWERunner,
+        task_id: str,
+        max_turns: int = 6,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.runner = runner
+        self.task_id = task_id
+        self.max_turns = max_turns
+
+    def setup_state(self, state: State | None = None) -> State:
+        st: State = state or {}
+        if st.get("_init_done"):
+            return st
+        initial_obs = self.runner.start(self.task_id)
+        st.update(
+            {
+                "_init_done": True,
+                "turn": 0,
+                "observation": initial_obs,
+                "done": False,
+                "passed": False,
+            }
+        )
+        return st
+
+    def _extract_patch(self, messages: Messages) -> str:
+        if isinstance(messages, list) and messages:
+            last = messages[-1]
+            content = last.get("content", "") if isinstance(last, dict) else str(last)
+        else:
+            content = str(messages)
+        return str(content)
+
+    def _append_tool_observation(self, messages: list[dict[str, Any]], obs: str) -> None:
+        messages.append({"role": "tool", "content": obs, "name": "tests"})
+
+    def is_completed(self, messages: Messages, state: State) -> bool:  # noqa: ARG002
+        return bool(state.get("done") or state.get("turn", 0) >= self.max_turns)
+
+    def env_response(self, messages: Messages, state: State) -> tuple[Messages, State]:
+        st = self.setup_state(state)
+        st["turn"] = st.get("turn", 0) + 1
+        patch_text = self._extract_patch(messages)
+        result: PatchStepResult = self.runner.apply_patch(patch_text)
+        st.update({"done": result.done, "passed": result.passed, "observation": result.observation})
+        # Clone messages to list for augmentation
+        msgs: list[dict[str, Any]]
+        if isinstance(messages, list):
+            msgs = list(messages)
+        else:
+            msgs = [{"role": "user", "content": str(messages)}]
+        self._append_tool_observation(msgs, result.observation)
+        return msgs, st

--- a/verifiers/integrations/multiswebench/__init__.py
+++ b/verifiers/integrations/multiswebench/__init__.py
@@ -1,0 +1,12 @@
+"""Multi-SWE-Bench integration shims.
+
+Defines a lightweight runner protocol to integrate Multi-SWE-Bench style
+program-repair tasks with the verifiers Environment API without hard deps.
+
+Production deployments should provide a concrete runner that talks to the
+official Multi-SWE-Bench harness to checkout repos, apply patches, run tests,
+and decide pass/fail. This package also includes a `StubRunner` suitable for
+CI smoke tests.
+"""
+
+from .runner import MultiSWERunner, PatchStepResult, StubRunner  # noqa: F401

--- a/verifiers/integrations/multiswebench/runner.py
+++ b/verifiers/integrations/multiswebench/runner.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+
+@dataclass
+class PatchStepResult:
+    observation: str
+    done: bool
+    passed: bool
+    info: dict[str, Any]
+
+
+class MultiSWERunner(Protocol):
+    """Protocol for running Multi‑SWE‑Bench tasks.
+
+    A concrete implementation should:
+    - fetch/prepare the target repo for a specific task id
+    - accept patches (e.g., unified diffs) proposed by the agent
+    - apply the patch, run the benchmark's tests, and report pass/fail
+    """
+
+    def start(self, task_id: str) -> str:
+        """Prepare task and return initial observation (e.g., failing tests)."""
+
+    def apply_patch(self, patch_text: str) -> PatchStepResult:
+        """Apply a patch and return test results and status."""
+
+
+class StubRunner:
+    """A minimal runner for smoke tests and development.
+
+    Marks success when a proposed patch contains an expected token.
+    """
+
+    def __init__(self, expected_token: str = "PASS_FIX", max_attempts: int = 3):
+        self.expected_token = expected_token
+        self.max_attempts = max_attempts
+        self.attempts = 0
+        self.started = False
+
+    def start(self, task_id: str) -> str:  # noqa: ARG002
+        self.attempts = 0
+        self.started = True
+        return "Failing tests: 1\n- test_example::test_should_pass (currently failing)\nSuggest a patch (unified diff) to fix."
+
+    def apply_patch(self, patch_text: str) -> PatchStepResult:
+        if not self.started:
+            raise RuntimeError("StubRunner.start() must be called before apply_patch().")
+        self.attempts += 1
+        done = False
+        passed = False
+        info: dict[str, Any] = {"attempts": self.attempts}
+        if self.expected_token in patch_text:
+            done = True
+            passed = True
+            obs = "All tests passed.\n"
+        else:
+            obs = "Tests still failing.\n"
+            if self.attempts >= self.max_attempts:
+                done = True
+                passed = False
+        return PatchStepResult(observation=obs, done=done, passed=passed, info=info)

--- a/verifiers/rubrics/multiswe_rubric.py
+++ b/verifiers/rubrics/multiswe_rubric.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from .rubric import Rubric
+from ..types import Messages, State
+
+
+class MultiSWERubric(Rubric):
+    """Simple rubric assigning 1.0 if tests pass, else 0.0."""
+
+    def __init__(self) -> None:
+        super().__init__(funcs=[self.pass_reward], weights=[1.0])
+
+    def pass_reward(self, parser, completion: Messages, answer: str | None = None, state: State | None = None) -> float:  # noqa: D401, ARG002
+        return 1.0 if state and state.get("passed") else 0.0


### PR DESCRIPTION
This PR adds a thin integration for Multi‑SWE‑Bench style program repair tasks.

Highlights
- Adapter env: `verifiers.envs.MultiSWEEnv` implementing a multi‑turn protocol where each assistant turn proposes a patch; the runner applies it and returns test results.
- Runner protocol: `verifiers.integrations.multiswebench.MultiSWERunner` + `PatchStepResult` dataclass; includes a `StubRunner` for CI/dev without external deps.
- Rubric: `MultiSWERubric` (1.0 when tests pass, else 0.0).
- Example env module: `environments/vf_multi_swe_bench` with `load_environment` for quick start.
- Docs: `docs/multiswebench_integration.md` with usage and production notes.
- Smoke test: `tests/test_multiswe_env.py` validates E2E with `mock_openai_client` and `StubRunner`.
- Package exports updated in `verifiers.__init__`.

Test plan
- `uv sync --all-extras`
- `uv run pytest -k 'multiswe or terminalbench' -q` → both tests pass locally.

Notes
- The `StubRunner` only checks for an expected token in the proposed patch. Replace it with a real runner to the official Multi‑SWE‑Bench harness (e.g., using their Docker workflow) to run actual repo checkouts and test suites.
