### PR TITLE
feat(multiswebench): add Multi‑SWE‑Bench HarnessRunner, env wiring, docs, and smoke test

### DIFF
--- a/docs/multiswebench_integration.md
+++ b/docs/multiswebench_integration.md
@@ -1,0 +1,43 @@
+# Multi‑SWE‑Bench Integration
+
+This repository includes a thin adapter for Multi‑SWE‑Bench style program repair tasks.
+
+- Env: `verifiers.envs.MultiSWEEnv`
+- Runner interface: `verifiers.integrations.multiswebench.MultiSWERunner`
+- Stub runner (for CI): `StubRunner` (no external deps)
+- Harness runner: `HarnessRunner` (uses official `multi_swe_bench` Python API)
+- Rubric: `MultiSWERubric` (1.0 pass, 0.0 fail)
+
+Quick usage with stub runner:
+
+```
+uv run vf-eval vf-multi-swe-bench -a '{"task_id":"stub","expected_token":"PASS_FIX"}' -n 1 -r 1
+```
+
+Production usage:
+- Use the built-in `HarnessRunner` by supplying a dataset file and task id.
+
+Example (single instance, stub OpenAI for model calls):
+
+```
+uv run vf-install vf-multi-swe-bench
+uv run vf-eval vf-multi-swe-bench \
+  -a '{
+        "task_id":"axios__axios-5919",
+        "dataset_file":"/mnt/beegfs/agents/model_repository/datasets/multi-swe-bench/js/axios__axios_dataset.jsonl",
+        "workdir":"./msb_work",
+        "output_dir":"./msb_out",
+        "repo_dir":"./msb_repos",
+        "max_workers":1
+      }' \
+  -n 1 -r 1 \
+  -m mock -b http://127.0.0.1:8009/v1 -k OPENAI_API_KEY
+```
+
+Notes:
+- Ensure Docker is available. First-run will build environment images and can take time.
+- `task_id` format is `<org>__<repo>-<number>` matching dataset entries.
+
+Testing:
+- Smoke test: `tests/test_multiswe_env.py` validates end-to-end flow with `mock_openai_client` and `StubRunner`.
+- Run: `uv run pytest -k multiswe -q`.

--- a/environments/vf_multi_swe_bench/README.md
+++ b/environments/vf_multi_swe_bench/README.md
@@ -1,0 +1,11 @@
+# vf-multi-swe-bench
+
+Multi‑SWE‑Bench adapter environment for verifiers. Wraps the `MultiSWEEnv` and
+uses a runner implementation to interact with the Multi‑SWE‑Bench harness.
+
+Quickstart (stub runner):
+
+```
+uv run vf-eval vf-multi-swe-bench -a '{"task_id":"stub-task","expected_token":"PASS_FIX"}' -n 1 -r 1
+```
+

--- a/environments/vf_multi_swe_bench/pyproject.toml
+++ b/environments/vf_multi_swe_bench/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "vf-multi-swe-bench"
+description = "Multi-SWE-Bench adapter environment for verifiers"
+version = "0.1.0"
+requires-python = ">=3.11,<3.13"
+dependencies = [
+    "verifiers>=0.1.2",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build]
+include = ["vf_multi_swe_bench.py"]
+

--- a/environments/vf_multi_swe_bench/vf_multi_swe_bench.py
+++ b/environments/vf_multi_swe_bench/vf_multi_swe_bench.py
@@ -1,0 +1,41 @@
+import verifiers as vf
+from verifiers.integrations.multiswebench import StubRunner
+
+try:
+    from verifiers.integrations.multiswebench import HarnessRunner
+except Exception:  # pragma: no cover - optional dependency
+    HarnessRunner = None  # type: ignore
+
+
+def load_environment(
+    task_id: str = "stub",
+    expected_token: str = "PASS_FIX",
+    dataset_file: str | None = None,
+    workdir: str | None = None,
+    output_dir: str | None = None,
+    repo_dir: str | None = None,
+    max_workers: int = 1,
+    force_build: bool = False,
+    **kwargs,
+) -> vf.Environment:
+    """Load a Multi‑SWE‑Bench environment.
+
+    Args:
+        task_id: Benchmark task identifier.
+        expected_token: For stub runner only; token that indicates a successful patch.
+    """
+    if dataset_file and HarnessRunner:
+        runner = HarnessRunner(
+            dataset_file=dataset_file,
+            workdir=workdir,
+            output_dir=output_dir,
+            repo_dir=repo_dir,
+            max_workers=max_workers,
+            force_build=force_build,
+        )
+    else:
+        runner = StubRunner(expected_token=expected_token)
+
+    env = vf.MultiSWEEnv(runner=runner, task_id=task_id)
+    env.rubric = vf.MultiSWERubric()  # simple pass/fail rubric
+    return env

--- a/tests/test_multiswe_harness_integration.py
+++ b/tests/test_multiswe_harness_integration.py
@@ -1,0 +1,53 @@
+import os
+import pathlib
+import pytest
+
+import verifiers as vf
+
+
+@pytest.mark.integration
+def test_multiswe_harness_runner_smoke(monkeypatch):
+    dataset_file = os.environ.get("MSB_DATASET_FILE")
+    task_id = os.environ.get("MSB_TASK_ID")
+    if not dataset_file or not task_id:
+        pytest.skip("Set MSB_DATASET_FILE and MSB_TASK_ID to run harness smoke test")
+
+    # Ensure file exists
+    assert pathlib.Path(dataset_file).exists()
+
+    env = vf.load_environment(
+        env_id="vf-multi-swe-bench",
+        task_id=task_id,
+        dataset_file=dataset_file,
+        workdir="./msb_work_test",
+        output_dir="./msb_out_test",
+        repo_dir="./msb_repos_test",
+        max_workers=1,
+        force_build=False,
+    )
+    env.rubric = vf.MultiSWERubric()
+
+    # Use a trivial patch to drive the loop; likely fails but should run the pipeline
+    prompt = [[{"role": "user", "content": "Propose a patch."}]]
+    client = object()  # not used by env; driver uses messages directly
+    # Use the ground-truth fix patch if available to maximize chance of success
+    import json
+    fix_patch = "diff --git a/README.md b/README.md\n--- a/README.md\n+++ b/README.md\n@@\n-foo\n+bar\n\n"
+    with open(dataset_file, "r", encoding="utf-8") as f:
+        for line in f:
+            item = json.loads(line)
+            inst_id = f"{item['org']}__{item['repo']}-{item['number']}"
+            if inst_id == task_id and item.get("fix_patch"):
+                fix_patch = item["fix_patch"]
+                break
+
+    results = env.evaluate(
+        client=client,
+        model="ignored",
+        sampling_args={"max_tokens": 1},
+        num_examples=1,
+        rollouts_per_example=1,
+        max_concurrent_requests=1,
+        driver=lambda *_args, **_kwargs: [{"role": "assistant", "content": fix_patch}],
+    )
+    assert len(results.reward) == 1

--- a/verifiers/envs/multiswe_env.py
+++ b/verifiers/envs/multiswe_env.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .multiturn_env import MultiTurnEnv
+from ..integrations.multiswebench import MultiSWERunner, PatchStepResult
+from ..types import Messages, State
+
+
+class MultiSWEEnv(MultiTurnEnv):
+    """Environment adapter for Multi‑SWE‑Bench style program repair tasks.
+
+    Each assistant message is interpreted as a proposed patch (e.g., unified
+    diff). The runner applies the patch and runs tests. The resulting
+    observation (test output summary) is appended as a tool message.
+    Completion is signaled by the runner when tests pass or attempts are
+    exhausted.
+    """
+
+    def __init__(
+        self,
+        runner: MultiSWERunner,
+        task_id: str,
+        max_turns: int = 6,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.runner = runner
+        self.task_id = task_id
+        self.max_turns = max_turns
+
+    def setup_state(self, state: State | None = None) -> State:
+        st: State = state or {}
+        if st.get("_init_done"):
+            return st
+        initial_obs = self.runner.start(self.task_id)
+        st.update(
+            {
+                "_init_done": True,
+                "turn": 0,
+                "observation": initial_obs,
+                "done": False,
+                "passed": False,
+            }
+        )
+        return st
+
+    def _extract_patch(self, messages: Messages) -> str:
+        if isinstance(messages, list) and messages:
+            last = messages[-1]
+            content = last.get("content", "") if isinstance(last, dict) else str(last)
+        else:
+            content = str(messages)
+        return str(content)
+
+    def _append_tool_observation(self, messages: list[dict[str, Any]], obs: str) -> None:
+        messages.append({"role": "tool", "content": obs, "name": "tests"})
+
+    def is_completed(self, messages: Messages, state: State) -> bool:  # noqa: ARG002
+        return bool(state.get("done") or state.get("turn", 0) >= self.max_turns)
+
+    def env_response(self, messages: Messages, state: State) -> tuple[Messages, State]:
+        st = self.setup_state(state)
+        st["turn"] = st.get("turn", 0) + 1
+        patch_text = self._extract_patch(messages)
+        result: PatchStepResult = self.runner.apply_patch(patch_text)
+        st.update({"done": result.done, "passed": result.passed, "observation": result.observation})
+        # Clone messages to list for augmentation
+        msgs: list[dict[str, Any]]
+        if isinstance(messages, list):
+            msgs = list(messages)
+        else:
+            msgs = [{"role": "user", "content": str(messages)}]
+        self._append_tool_observation(msgs, result.observation)
+        return msgs, st
+

--- a/verifiers/integrations/multiswebench/__init__.py
+++ b/verifiers/integrations/multiswebench/__init__.py
@@ -1,0 +1,17 @@
+"""Multi-SWE-Bench integration shims.
+
+Defines a lightweight runner protocol to integrate Multi-SWE-Bench style
+program-repair tasks with the verifiers Environment API without hard deps.
+
+Production deployments should provide a concrete runner that talks to the
+official Multi-SWE-Bench harness to checkout repos, apply patches, run tests,
+and decide pass/fail. This package also includes a `StubRunner` suitable for
+CI smoke tests.
+"""
+
+from .runner import (
+    MultiSWERunner,
+    PatchStepResult,
+    StubRunner,
+    HarnessRunner,
+)  # noqa: F401

--- a/verifiers/integrations/multiswebench/runner.py
+++ b/verifiers/integrations/multiswebench/runner.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol
+import json
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+@dataclass
+class PatchStepResult:
+    observation: str
+    done: bool
+    passed: bool
+    info: dict[str, Any]
+
+
+class MultiSWERunner(Protocol):
+    """Protocol for running Multi‑SWE‑Bench tasks.
+
+    A concrete implementation should:
+    - fetch/prepare the target repo for a specific task id
+    - accept patches (e.g., unified diffs) proposed by the agent
+    - apply the patch, run the benchmark's tests, and report pass/fail
+    """
+
+    def start(self, task_id: str) -> str:
+        """Prepare task and return initial observation (e.g., failing tests)."""
+
+    def apply_patch(self, patch_text: str) -> PatchStepResult:
+        """Apply a patch and return test results and status."""
+
+
+class StubRunner:
+    """A minimal runner for smoke tests and development.
+
+    Marks success when a proposed patch contains an expected token.
+    """
+
+    def __init__(self, expected_token: str = "PASS_FIX", max_attempts: int = 3):
+        self.expected_token = expected_token
+        self.max_attempts = max_attempts
+        self.attempts = 0
+        self.started = False
+
+    def start(self, task_id: str) -> str:  # noqa: ARG002
+        self.attempts = 0
+        self.started = True
+        return "Failing tests: 1\n- test_example::test_should_pass (currently failing)\nSuggest a patch (unified diff) to fix."
+
+    def apply_patch(self, patch_text: str) -> PatchStepResult:
+        if not self.started:
+            raise RuntimeError("StubRunner.start() must be called before apply_patch().")
+        self.attempts += 1
+        done = False
+        passed = False
+        info: dict[str, Any] = {"attempts": self.attempts}
+        if self.expected_token in patch_text:
+            done = True
+            passed = True
+            obs = "All tests passed.\n"
+        else:
+            obs = "Tests still failing.\n"
+            if self.attempts >= self.max_attempts:
+                done = True
+                passed = False
+        return PatchStepResult(observation=obs, done=done, passed=passed, info=info)
+
+
+class HarnessRunner:
+    """Multi‑SWE‑Bench runner backed by the official harness.
+
+    This runner shells out to `python -m multi_swe_bench.harness.run_evaluation`
+    for a single instance at a time. It expects Docker to be available.
+
+    task_id format: "<org>__<repo>-<number>" (e.g., "axios__axios-5919").
+
+    Args:
+        dataset_file: Path to a dataset JSONL file (one of the downloaded
+            Multi‑SWE‑Bench dataset shards).
+        workdir: Working directory for the harness (build caches, etc.).
+        output_dir: Output directory for logs and reports.
+        repo_dir: Directory where target repositories can be cloned.
+        max_workers: Parallelism for the harness (kept low for single instance).
+        force_build: Whether to force rebuild images.
+        cache_level: Image cache level ("env" recommended).
+        log_level: Harness log level.
+        extra_env: Extra env vars to set for subprocess calls.
+    """
+
+    def __init__(
+        self,
+        dataset_file: str,
+        workdir: str | None = None,
+        output_dir: str | None = None,
+        repo_dir: str | None = None,
+        max_workers: int = 1,
+        force_build: bool = False,
+        cache_level: str = "env",
+        log_level: str = "INFO",
+        extra_env: dict[str, str] | None = None,
+    ) -> None:
+        self.dataset_file = str(dataset_file)
+        self.workdir = str(workdir or Path("./msb_work").absolute())
+        self.output_dir = str(output_dir or Path("./msb_out").absolute())
+        self.repo_dir = str(repo_dir or Path("./msb_repos").absolute())
+        self.max_workers = max_workers
+        self.force_build = force_build
+        self.cache_level = cache_level
+        self.log_level = log_level
+        self.extra_env = extra_env or {}
+
+        Path(self.workdir).mkdir(parents=True, exist_ok=True)
+        Path(self.output_dir).mkdir(parents=True, exist_ok=True)
+        Path(self.repo_dir).mkdir(parents=True, exist_ok=True)
+
+        # Preload dataset index for quick lookup
+        self._index: dict[str, dict[str, Any]] = {}
+        with open(self.dataset_file, "r", encoding="utf-8") as f:
+            for line in f:
+                if not line.strip():
+                    continue
+                item = json.loads(line)
+                inst_id = f"{item['org']}__{item['repo']}-{item['number']}"
+                self._index[inst_id] = item
+
+        self._current_task: str | None = None
+
+    def _parse_task(self, task_id: str) -> dict[str, Any]:
+        if task_id not in self._index:
+            raise ValueError(
+                f"Unknown task_id '{task_id}'. Ensure it exists in {self.dataset_file}"
+            )
+        return self._index[task_id]
+
+    def _run_harness(self, config: dict[str, Any]) -> tuple[bool, str]:
+        with tempfile.TemporaryDirectory() as td:
+            cfg_path = Path(td) / "config.json"
+            cfg_path.write_text(json.dumps(config), encoding="utf-8")
+            cmd = [
+                shutil.which("python") or "python",
+                "-m",
+                "multi_swe_bench.harness.run_evaluation",
+                "--config",
+                str(cfg_path),
+            ]
+            env = os.environ.copy()
+            env.update(self.extra_env)
+            proc = subprocess.run(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                env=env,
+            )
+            out = proc.stdout
+            # Best-effort parse: when single instance is run, a per-instance
+            # report.json is created under logs dir; but also a final_report.json
+            # may be created under output_dir.
+            # We scan output_dir for any report.json to read a resolved flag.
+            reports = list(Path(self.output_dir).rglob("report.json"))
+            resolved = False
+            if reports:
+                try:
+                    data = json.loads(reports[0].read_text())
+                    # report keyed by instance id
+                    for v in data.values():
+                        if isinstance(v, dict) and "resolved" in v:
+                            resolved = bool(v["resolved"])
+                            break
+                except Exception:
+                    pass
+            return resolved, out
+
+    def start(self, task_id: str) -> str:
+        self._current_task = task_id
+        _ = self._parse_task(task_id)
+        return (
+            "Multi‑SWE‑Bench instance prepared. Provide a unified diff patch to apply.\n"
+            "Format: output of `git diff -U` with proper file paths."
+        )
+
+    def apply_patch(self, patch_text: str) -> PatchStepResult:
+        if not self._current_task:
+            raise RuntimeError("HarnessRunner.start() must be called first.")
+        item = self._parse_task(self._current_task)
+        inst_id = self._current_task
+
+        # Write a single‑instance patch file in JSONL format
+        patch_dir = Path(self.workdir) / "patches"
+        patch_dir.mkdir(parents=True, exist_ok=True)
+        patch_path = patch_dir / f"{inst_id}.jsonl"
+        patch_obj = {
+            "org": item["org"],
+            "repo": item["repo"],
+            "number": item["number"],
+            "fix_patch": patch_text,
+        }
+        patch_path.write_text(json.dumps(patch_obj) + "\n", encoding="utf-8")
+
+        # Build harness config for a single instance
+        log_dir = Path(self.output_dir) / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        cfg = {
+            "mode": "evaluation",
+            "workdir": self.workdir,
+            "patch_files": [str(patch_path)],
+            "dataset_files": [self.dataset_file],
+            "force_build": self.force_build,
+            "output_dir": self.output_dir,
+            "specifics": [inst_id],
+            "skips": [],
+            "repo_dir": self.repo_dir,
+            "need_clone": True,
+            "global_env": [],
+            "clear_env": True,
+            "stop_on_error": True,
+            "max_workers": self.max_workers,
+            "max_workers_build_image": max(1, self.max_workers),
+            "max_workers_run_instance": max(1, self.max_workers),
+            "log_dir": str(log_dir),
+            "log_level": self.log_level,
+        }
+
+        resolved, logs = self._run_harness(cfg)
+        obs = "All tests passed.\n" if resolved else "Tests still failing.\n"
+        info = {"instance": inst_id, "logs_tail": logs[-2000:]}
+        done = resolved  # stop when resolved, otherwise allow more tries
+        return PatchStepResult(observation=obs, done=done, passed=resolved, info=info)


### PR DESCRIPTION
Summary
- Add verifiers.integrations.multiswebench.HarnessRunner that shells out to the official multi_swe_bench harness for single‑instance evaluation (Docker required).
- Wire vf-multi-swe-bench environment to auto‑select HarnessRunner when a dataset_file is provided; fallback to StubRunner otherwise.
- Add docs/multiswebench_integration.md with CLI usage examples, including running via vf-eval and stub OpenAI base URL.
- Add optional integration test tests/test_multiswe_harness_integration.py (skipped unless MSB_DATASET_FILE and MSB_TASK_ID are set). Uses ground‑truth fix_patch to maximize success likelihood.

Setup
- Dataset: expects public JSONL files from ByteDance-Seed/Multi-SWE-bench downloaded under /mnt/beegfs/agents/model_repository/datasets (documented and used in examples). Any JSONL shard works.
- Docker: required for harness; first builds can take time.
- OpenAI calls: for Terminal-Bench smoke we used a tiny local stub server to satisfy vf-eval; for Multi‑SWE‑Bench the harness runner doesn’t rely on networked LLM calls.

Notes
- Kept changes focused; no alterations to core evaluation flow.
- Guarded the harness test to avoid CI flakiness.

Next Steps
- If desired, add a tiny examples config and a CI job matrix to run 1–2 fast instances nightly (gated behind a label).
