### PR TITLE
feat(multiswebench): add HarnessRunner, env wiring, docs, and integration smoke test (conflict-free)

### DIFF
--- a/docs/multiswebench_integration.md
+++ b/docs/multiswebench_integration.md
@@ -5,6 +5,7 @@ This repository includes a thin adapter for Multi‑SWE‑Bench style program re
 - Env: `verifiers.envs.MultiSWEEnv`
 - Runner interface: `verifiers.integrations.multiswebench.MultiSWERunner`
 - Stub runner (for CI): `StubRunner` (no external deps)
+- Harness runner: `HarnessRunner` (uses official `multi_swe_bench` Python API)
 - Rubric: `MultiSWERubric` (1.0 pass, 0.0 fail)
 
 Quick usage with stub runner:
@@ -14,9 +15,29 @@ uv run vf-eval vf-multi-swe-bench -a '{"task_id":"stub","expected_token":"PASS_F
 ```
 
 Production usage:
-- Implement a `MultiSWERunner` using the official harness to checkout repos, apply patches, run tests, and return pass/fail.
-- Inject your runner into `vf-multi-swe-bench` or your own environment module.
+- Use the built-in `HarnessRunner` by supplying a dataset file and task id.
 - Use `vf-eval` for evaluations and `report_utils` for HTML reports.
+
+Example (single instance, stub OpenAI for model calls):
+
+```
+uv run vf-install vf-multi-swe-bench
+uv run vf-eval vf-multi-swe-bench \
+  -a '{
+        "task_id":"axios__axios-5919",
+        "dataset_file":"/mnt/beegfs/agents/model_repository/datasets/multi-swe-bench/js/axios__axios_dataset.jsonl",
+        "workdir":"./msb_work",
+        "output_dir":"./msb_out",
+        "repo_dir":"./msb_repos",
+        "max_workers":1
+      }' \
+  -n 1 -r 1 \
+  -m mock -b http://127.0.0.1:8009/v1 -k OPENAI_API_KEY
+```
+
+Notes:
+- Ensure Docker is available. First-run will build environment images and can take time.
+- `task_id` format is `<org>__<repo>-<number>` matching dataset entries.
 
 Testing:
 - Smoke test: `tests/test_multiswe_env.py` validates end-to-end flow with `mock_openai_client` and `StubRunner`.

--- a/environments/vf_multi_swe_bench/vf_multi_swe_bench.py
+++ b/environments/vf_multi_swe_bench/vf_multi_swe_bench.py
@@ -1,15 +1,60 @@
 import verifiers as vf
 from verifiers.integrations.multiswebench import StubRunner
 
+try:
+    from verifiers.integrations.multiswebench import HarnessRunner
+except Exception:  # pragma: no cover - optional dependency
+    HarnessRunner = None  # type: ignore
 
-def load_environment(task_id: str = "stub", expected_token: str = "PASS_FIX", **kwargs) -> vf.Environment:  # noqa: ARG001
+
+def load_environment(
+    task_id: str = "stub",
+    expected_token: str = "PASS_FIX",
+    dataset_file: str | None = None,
+    workdir: str | None = None,
+    output_dir: str | None = None,
+    repo_dir: str | None = None,
+    max_workers: int = 1,
+    force_build: bool = False,
+    **kwargs,
+) -> vf.Environment:
     """Load a Multi‑SWE‑Bench environment.
 
     Args:
         task_id: Benchmark task identifier.
         expected_token: For stub runner only; token that indicates a successful patch.
     """
-    runner = StubRunner(expected_token=expected_token)
-    env = vf.MultiSWEEnv(runner=runner, task_id=task_id)
+    if dataset_file and HarnessRunner:
+        runner = HarnessRunner(
+            dataset_file=dataset_file,
+            workdir=workdir,
+            output_dir=output_dir,
+            repo_dir=repo_dir,
+            max_workers=max_workers,
+            force_build=force_build,
+        )
+    else:
+        runner = StubRunner(expected_token=expected_token)
+
+    # Provide a minimal single-example eval dataset if not supplied,
+    # so the environment can run directly via `vf-eval`.
+    eval_dataset = kwargs.get("eval_dataset")
+    if eval_dataset is None:
+        from datasets import Dataset
+
+        instruction = (
+            "Propose a unified diff patch to fix the failing tests. "
+            "Respond with only the patch."
+        )
+        eval_dataset = Dataset.from_dict(
+            {
+                "prompt": [[{"role": "user", "content": instruction}]],
+                "answer": ["OK"],
+                "info": [{}],
+                "task": [task_id],
+            }
+        )
+
+    env = vf.MultiSWEEnv(runner=runner, task_id=task_id, eval_dataset=eval_dataset)
     env.rubric = vf.MultiSWERubric()  # simple pass/fail rubric
     return env

--- a/tests/test_multiswe_harness_integration.py
+++ b/tests/test_multiswe_harness_integration.py
@@ -1,0 +1,68 @@
+import os
+import json
+import pathlib
+import pytest
+from datasets import Dataset
+
+import verifiers as vf
+
+
+@pytest.mark.integration
+def test_multiswe_harness_runner_smoke(mock_openai_client):
+    dataset_file = os.environ.get("MSB_DATASET_FILE")
+    task_id = os.environ.get("MSB_TASK_ID")
+    if not dataset_file or not task_id:
+        pytest.skip("Set MSB_DATASET_FILE and MSB_TASK_ID to run harness smoke test")
+
+    # Ensure file exists
+    assert pathlib.Path(dataset_file).exists()
+
+    # Prepare a minimal single-example dataset driving one patch attempt
+    ds = Dataset.from_dict(
+        {
+            "prompt": [[{"role": "user", "content": "Propose a patch to fix tests."}]],
+            "answer": ["OK"],
+            "info": [{}],
+            "task": [task_id],
+        }
+    )
+
+    env = vf.load_environment(
+        env_id="vf-multi-swe-bench",
+        task_id=task_id,
+        dataset_file=dataset_file,
+        workdir="./msb_work_test",
+        output_dir="./msb_out_test",
+        repo_dir="./msb_repos_test",
+        max_workers=1,
+        force_build=False,
+    )
+    env.rubric = vf.MultiSWERubric()
+
+    # Ground-truth patch to maximize success likelihood
+    fix_patch = None
+    with open(dataset_file, "r", encoding="utf-8") as f:
+        for line in f:
+            item = json.loads(line)
+            inst_id = f"{item['org']}__{item['repo']}-{item['number']}"
+            if inst_id == task_id and item.get("fix_patch"):
+                fix_patch = item["fix_patch"]
+                break
+    assert fix_patch, "No fix_patch found in dataset for the specified task"
+
+    # Stub the model to produce the exact fix_patch at first turn
+    mock_openai_client.add_chat_response(
+        messages=[{"role": "user", "content": "Propose a patch to fix tests."}],
+        response=fix_patch,
+    )
+
+    env.eval_dataset = ds
+    results = env.evaluate(
+        client=mock_openai_client,
+        model="dummy-chat",
+        sampling_args={"max_tokens": 2048, "temperature": 0.0},
+        num_examples=1,
+        rollouts_per_example=1,
+        max_concurrent=1,
+    )
+    assert len(results.reward) == 1

--- a/verifiers/integrations/multiswebench/__init__.py
+++ b/verifiers/integrations/multiswebench/__init__.py
@@ -9,4 +9,9 @@ and decide pass/fail. This package also includes a `StubRunner` suitable for
 CI smoke tests.
 """
 
-from .runner import MultiSWERunner, PatchStepResult, StubRunner  # noqa: F401
+from .runner import (
+    MultiSWERunner,
+    PatchStepResult,
+    StubRunner,
+    HarnessRunner,
+)  # noqa: F401

--- a/verifiers/integrations/multiswebench/runner.py
+++ b/verifiers/integrations/multiswebench/runner.py
@@ -2,6 +2,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Any, Protocol
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
 
 
 @dataclass
@@ -62,3 +68,162 @@ class StubRunner:
                 done = True
                 passed = False
         return PatchStepResult(observation=obs, done=done, passed=passed, info=info)
+
+
+class HarnessRunner:
+    """Multi‑SWE‑Bench runner backed by the official harness.
+
+    This runner shells out to `python -m multi_swe_bench.harness.run_evaluation`
+    for a single instance at a time. It expects Docker to be available.
+
+    task_id format: "<org>__<repo>-<number>" (e.g., "axios__axios-5919").
+
+    Args:
+        dataset_file: Path to a dataset JSONL file (one of the downloaded
+            Multi‑SWE‑Bench dataset shards).
+        workdir: Working directory for the harness (build caches, etc.).
+        output_dir: Output directory for logs and reports.
+        repo_dir: Directory where target repositories can be cloned.
+        max_workers: Parallelism for the harness (kept low for single instance).
+        force_build: Whether to force rebuild images.
+        cache_level: Image cache level ("env" recommended).
+        log_level: Harness log level.
+        extra_env: Extra env vars to set for subprocess calls.
+    """
+
+    def __init__(
+        self,
+        dataset_file: str,
+        workdir: str | None = None,
+        output_dir: str | None = None,
+        repo_dir: str | None = None,
+        max_workers: int = 1,
+        force_build: bool = False,
+        cache_level: str = "env",
+        log_level: str = "INFO",
+        extra_env: dict[str, str] | None = None,
+    ) -> None:
+        self.dataset_file = str(dataset_file)
+        self.workdir = str(workdir or Path("./msb_work").absolute())
+        self.output_dir = str(output_dir or Path("./msb_out").absolute())
+        self.repo_dir = str(repo_dir or Path("./msb_repos").absolute())
+        self.max_workers = max_workers
+        self.force_build = force_build
+        self.cache_level = cache_level
+        self.log_level = log_level
+        self.extra_env = extra_env or {}
+
+        Path(self.workdir).mkdir(parents=True, exist_ok=True)
+        Path(self.output_dir).mkdir(parents=True, exist_ok=True)
+        Path(self.repo_dir).mkdir(parents=True, exist_ok=True)
+
+        # Preload dataset index for quick lookup
+        self._index: dict[str, dict[str, Any]] = {}
+        with open(self.dataset_file, "r", encoding="utf-8") as f:
+            for line in f:
+                if not line.strip():
+                    continue
+                item = json.loads(line)
+                inst_id = f"{item['org']}__{item['repo']}-{item['number']}"
+                self._index[inst_id] = item
+
+        self._current_task: str | None = None
+
+    def _parse_task(self, task_id: str) -> dict[str, Any]:
+        if task_id not in self._index:
+            raise ValueError(
+                f"Unknown task_id '{task_id}'. Ensure it exists in {self.dataset_file}"
+            )
+        return self._index[task_id]
+
+    def _run_harness(self, config: dict[str, Any]) -> tuple[bool, str]:
+        with tempfile.TemporaryDirectory() as td:
+            cfg_path = Path(td) / "config.json"
+            cfg_path.write_text(json.dumps(config), encoding="utf-8")
+            cmd = [
+                shutil.which("python") or "python",
+                "-m",
+                "multi_swe_bench.harness.run_evaluation",
+                "--config",
+                str(cfg_path),
+            ]
+            env = os.environ.copy()
+            env.update(self.extra_env)
+            proc = subprocess.run(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                env=env,
+            )
+            out = proc.stdout
+            # Scan output_dir for a report.json and check resolved flag
+            reports = list(Path(self.output_dir).rglob("report.json"))
+            resolved = False
+            if reports:
+                try:
+                    data = json.loads(reports[0].read_text())
+                    for v in data.values():
+                        if isinstance(v, dict) and "resolved" in v:
+                            resolved = bool(v["resolved"])
+                            break
+                except Exception:
+                    pass
+            return resolved, out
+
+    def start(self, task_id: str) -> str:
+        self._current_task = task_id
+        _ = self._parse_task(task_id)
+        return (
+            "Multi‑SWE‑Bench instance prepared. Provide a unified diff patch to apply.\n"
+            "Format: output of `git diff -U` with proper file paths."
+        )
+
+    def apply_patch(self, patch_text: str) -> PatchStepResult:
+        if not self._current_task:
+            raise RuntimeError("HarnessRunner.start() must be called first.")
+        item = self._parse_task(self._current_task)
+        inst_id = self._current_task
+
+        # Write a single‑instance patch file in JSONL format
+        patch_dir = Path(self.workdir) / "patches"
+        patch_dir.mkdir(parents=True, exist_ok=True)
+        patch_path = patch_dir / f"{inst_id}.jsonl"
+        patch_obj = {
+            "org": item["org"],
+            "repo": item["repo"],
+            "number": item["number"],
+            "fix_patch": patch_text,
+        }
+        patch_path.write_text(json.dumps(patch_obj) + "\n", encoding="utf-8")
+
+        # Build harness config for a single instance
+        log_dir = Path(self.output_dir) / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        inst_harness_id = f"{item['org']}/{item['repo']}:pr-{item['number']}"
+        cfg = {
+            "mode": "evaluation",
+            "workdir": self.workdir,
+            "patch_files": [str(patch_path)],
+            "dataset_files": [self.dataset_file],
+            "force_build": self.force_build,
+            "output_dir": self.output_dir,
+            "specifics": [inst_harness_id],
+            "skips": [],
+            "repo_dir": self.repo_dir,
+            "need_clone": True,
+            "global_env": [],
+            "clear_env": True,
+            "stop_on_error": True,
+            "max_workers": self.max_workers,
+            "max_workers_build_image": max(1, self.max_workers),
+            "max_workers_run_instance": max(1, self.max_workers),
+            "log_dir": str(log_dir),
+            "log_level": self.log_level,
+        }
+
+        resolved, logs = self._run_harness(cfg)
+        obs = "All tests passed.\n" if resolved else "Tests still failing.\n"
+        info = {"instance": inst_id, "logs_tail": logs[-2000:]}
+        done = resolved
+        return PatchStepResult(observation=obs, done=done, passed=resolved, info=info)


### PR DESCRIPTION
This supersedes #5 by rebasing changes onto `main` to resolve conflicts cleanly.

What’s included:
- `verifiers.integrations.multiswebench.HarnessRunner` that shells out to the official `multi_swe_bench` harness for single-instance evaluation (Docker required).
- `vf-multi-swe-bench` environment now auto-selects `HarnessRunner` when `dataset_file` is provided; otherwise falls back to `StubRunner`.
- Updated docs with production usage example and notes.
- Added optional integration test `tests/test_multiswe_harness_integration.py` (skipped unless `MSB_DATASET_FILE` and `MSB_TASK_ID` are set). Uses ground-truth `fix_patch`.

Rationale:
- Original PR #5 was in `dirty` state due to concurrent additions on `main` (both-added file and overlapping edits). This branch contains the merged result aligned with repository structure and style.

If approved, we can close #5 after merging this.