### PR TITLE
fix(multiswebench): parse final_report.json, stronger test, export MultiSWE symbols

### DIFF
--- a/tests/test_multiswe_harness_integration.py
+++ b/tests/test_multiswe_harness_integration.py
@@ -66,3 +66,4 @@ def test_multiswe_harness_runner_smoke(mock_openai_client):
         max_concurrent=1,
     )
     assert len(results.reward) == 1
+    assert results.reward[0] == 1.0

--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -29,6 +29,7 @@ from .envs.multiturn_env import MultiTurnEnv
 from .envs.singleturn_env import SingleTurnEnv
 from .envs.tool_env import ToolEnv
 from .envs.terminalbench_env import TerminalBenchEnv
+from .envs.multiswe_env import MultiSWEEnv
 from .parsers.parser import Parser
 from .parsers.think_parser import ThinkParser
 from .parsers.xml_parser import XMLParser
@@ -37,6 +38,7 @@ from .rubrics.rubric import Rubric
 from .rubrics.rubric_group import RubricGroup
 from .rubrics.tool_rubric import ToolRubric
 from .rubrics.terminalbench_rubric import TerminalBenchRubric
+from .rubrics.multiswe_rubric import MultiSWERubric
 from .utils.data_utils import (
     extract_boxed_answer,
     extract_hash_answer,
@@ -112,6 +114,7 @@ __all__ = [
     "SingleTurnEnv",
     "ToolEnv",
     "TerminalBenchEnv",
+    "MultiSWEEnv",
     "EnvGroup",
     "extract_boxed_answer",
     "extract_hash_answer",
@@ -123,6 +126,7 @@ __all__ = [
 # Additional exports for optional integrations
 __all__.extend([
     "TerminalBenchRubric",
+    "MultiSWERubric",
 ])
 
 # Add trainer exports only if trl is available

--- a/verifiers/integrations/multiswebench/runner.py
+++ b/verifiers/integrations/multiswebench/runner.py
@@ -157,19 +157,70 @@ class HarnessRunner:
                 env=env,
             )
             out = proc.stdout
-            # Scan output_dir for a report.json and check resolved flag
-            reports = list(Path(self.output_dir).rglob("report.json"))
+
+            # Robust success detection: prefer final_report.json in output_dir
             resolved = False
-            if reports:
-                try:
-                    data = json.loads(reports[0].read_text())
-                    for v in data.values():
-                        if isinstance(v, dict) and "resolved" in v:
-                            resolved = bool(v["resolved"])
-                            break
-                except Exception:
-                    pass
+            final_report = Path(self.output_dir) / "final_report.json"
+            try:
+                if final_report.exists():
+                    data = json.loads(final_report.read_text())
+                    resolved = self._report_indicates_resolved(data)
+                else:
+                    # Fallback for older schemas: scan any report.json
+                    reports = list(Path(self.output_dir).rglob("report.json"))
+                    if reports:
+                        data = json.loads(reports[0].read_text())
+                        resolved = self._report_indicates_resolved(data)
+            except Exception:
+                # Leave resolved = False on parse errors
+                pass
+
             return resolved, out
+
+    def _report_indicates_resolved(self, data: Any) -> bool:
+        """Infer resolution for the current task from known report shapes.
+
+        Tries multiple schema variants seen in Multi‑SWE‑Bench reports:
+        - { "resolved_instances": ["org/repo:pr-N", ...], ... }
+        - { "instances": { "org/repo:pr-N": { "resolved": true, ... }, ... } }
+        - Nested dicts containing a boolean "resolved" (last‑resort heuristic)
+        """
+        if not self._current_task:
+            return False
+        item = self._parse_task(self._current_task)
+        inst_harness_id = f"{item['org']}/{item['repo']}:pr-{item['number']}"
+        inst_dataset_id = f"{item['org']}__{item['repo']}-{item['number']}"
+
+        # 1) resolved_instances list
+        try:
+            resolved_list = data.get("resolved_instances")
+            if isinstance(resolved_list, list):
+                if inst_harness_id in resolved_list or inst_dataset_id in resolved_list:
+                    return True
+        except Exception:
+            pass
+
+        # 2) instances map with per‑instance dicts containing resolved
+        try:
+            instances = data.get("instances")
+            if isinstance(instances, dict):
+                rec = instances.get(inst_harness_id) or instances.get(inst_dataset_id)
+                if isinstance(rec, dict) and isinstance(rec.get("resolved"), bool):
+                    return bool(rec["resolved"])
+        except Exception:
+            pass
+
+        # 3) Last resort: any nested dict with resolved=True
+        def any_resolved(obj: Any) -> bool:
+            if isinstance(obj, dict):
+                if isinstance(obj.get("resolved"), bool) and obj.get("resolved"):
+                    return True
+                return any(any_resolved(v) for v in obj.values())
+            if isinstance(obj, list):
+                return any(any_resolved(v) for v in obj)
+            return False
+
+        return any_resolved(data)
 
     def start(self, task_id: str) -> str:
         self._current_task = task_id


### PR DESCRIPTION
Summary
- Fix Multi‑SWE HarnessRunner success detection: read `final_report.json` and check resolution using documented schema patterns; keep a fallback to legacy `report.json`.
- Strengthen the harness smoke test: when a dataset `fix_patch` is provided and stubbed, assert `reward[0] == 1.0` instead of only checking length.
- Export `MultiSWEEnv` and `MultiSWERubric` at top level in `verifiers/__init__.py` to align with examples/tests.

Rationale
Audits 1 and 2 identified a critical bug (looking for `report.json` instead of `final_report.json`) and a weak test that wouldn’t catch success mis‑detection. This PR addresses both, and ensures the public API consistently exposes Multi‑SWE symbols like Terminal‑Bench does.

Notes
- No behavior changes to Terminal‑Bench integration in this PR.
- The success detection supports multiple plausible report shapes and falls back safely.