### PR TITLE
chore(runners): sys.executable, timeouts, return-code checks; default TB agent to 'terminus'

### DIFF
--- a/verifiers/integrations/multiswebench/runner.py
+++ b/verifiers/integrations/multiswebench/runner.py
@@ -7,6 +7,7 @@ import os
 import shutil
 import subprocess
 import tempfile
+import sys
 from pathlib import Path
 
 
@@ -90,6 +91,7 @@ class HarnessRunner:
         cache_level: str = "env",
         log_level: str = "INFO",
         extra_env: dict[str, str] | None = None,
+        timeout_sec: int = 1800,
     ) -> None:
         self.dataset_file = str(dataset_file)
         self.workdir = str(workdir or Path("./msb_work").absolute())
@@ -100,6 +102,7 @@ class HarnessRunner:
         self.cache_level = cache_level
         self.log_level = log_level
         self.extra_env = extra_env or {}
+        self.timeout_sec = timeout_sec
 
         Path(self.workdir).mkdir(parents=True, exist_ok=True)
         Path(self.output_dir).mkdir(parents=True, exist_ok=True)
@@ -129,7 +132,7 @@ class HarnessRunner:
             cfg_path = Path(td) / "config.json"
             cfg_path.write_text(json.dumps(config), encoding="utf-8")
             cmd = [
-                shutil.which("python") or "python",
+                sys.executable,
                 "-m",
                 "multi_swe_bench.harness.run_evaluation",
                 "--config",
@@ -137,14 +140,23 @@ class HarnessRunner:
             ]
             env = os.environ.copy()
             env.update(self.extra_env)
-            proc = subprocess.run(
-                cmd,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                text=True,
-                env=env,
-            )
-            out = proc.stdout
+            try:
+                proc = subprocess.run(
+                    cmd,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                    env=env,
+                    timeout=self.timeout_sec,
+                )
+                out = proc.stdout
+                if proc.returncode != 0:
+                    # Treat non-zero return as failure and surface tail
+                    tail = out[-2000:] if out else ""
+                    return False, f"Harness exited with code {proc.returncode}.\n{tail}"
+            except subprocess.TimeoutExpired as e:
+                out = (e.stdout or "") + (e.stderr or "")
+                return False, f"Harness timed out after {self.timeout_sec}s.\n{out[-2000:]}"
 
             # Robust success detection: prefer final_report.json in output_dir
             resolved = False
@@ -276,6 +288,7 @@ class OpenHandsRunner(HarnessRunner):
         force_build: bool = False,
         log_level: str = "INFO",
         extra_env: dict[str, str] | None = None,
+        timeout_sec: int = 1800,
     ) -> None:
         super().__init__(
             dataset_file=dataset_file,
@@ -287,6 +300,7 @@ class OpenHandsRunner(HarnessRunner):
             cache_level="env",
             log_level=log_level,
             extra_env=extra_env,
+            timeout_sec=timeout_sec,
         )
         self.entrypoint_module = entrypoint_module
         self.entrypoint_args = entrypoint_args or []
@@ -296,7 +310,7 @@ class OpenHandsRunner(HarnessRunner):
             cfg_path = Path(td) / "config.json"
             cfg_path.write_text(json.dumps(config), encoding="utf-8")
             cmd = [
-                shutil.which("python") or "python",
+                sys.executable,
                 "-m",
                 self.entrypoint_module,
                 "--config",
@@ -305,14 +319,22 @@ class OpenHandsRunner(HarnessRunner):
             ]
             env = os.environ.copy()
             env.update(self.extra_env)
-            proc = subprocess.run(
-                cmd,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                text=True,
-                env=env,
-            )
-            out = proc.stdout
+            try:
+                proc = subprocess.run(
+                    cmd,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                    env=env,
+                    timeout=self.timeout_sec,
+                )
+                out = proc.stdout
+                if proc.returncode != 0:
+                    tail = out[-2000:] if out else ""
+                    return False, f"OpenHands harness exited with code {proc.returncode}.\n{tail}"
+            except subprocess.TimeoutExpired as e:
+                out = (e.stdout or "") + (e.stderr or "")
+                return False, f"OpenHands harness timed out after {self.timeout_sec}s.\n{out[-2000:]}"
 
             resolved = False
             final_report = Path(self.output_dir) / "final_report.json"

--- a/verifiers/integrations/terminalbench/runner.py
+++ b/verifiers/integrations/terminalbench/runner.py
@@ -7,6 +7,7 @@ import os
 import shutil
 import subprocess
 import tempfile
+import sys
 from pathlib import Path
 
 
@@ -62,10 +63,10 @@ class StubRunner:
 
 
 class HarnessRunner:
-    """Terminal‑Bench runner using the official harness with the Terminus‑1 agent.
+    """Terminal‑Bench runner using the official harness with the Terminus agent.
 
     This runner shells out to a user‑configurable module entry point for the
-    Terminal‑Bench harness and runs a single task with the Terminus‑1 agent.
+    Terminal‑Bench harness and runs a single task with the Terminus agent.
 
     Notes:
     - The Terminal‑Bench harness typically controls the agent end‑to‑end. Since
@@ -80,8 +81,9 @@ class HarnessRunner:
         output_path: str | None = None,
         entrypoint_module: str | None = None,
         entrypoint_args: list[str] | None = None,
-        agent_name: str = "terminus_1",
+        agent_name: str = "terminus",
         extra_env: dict[str, str] | None = None,
+        timeout_sec: int = 1800,
     ) -> None:
         self.dataset_path = str(dataset_path)
         self.output_path = str(output_path or Path("./tb_runs").absolute())
@@ -89,6 +91,7 @@ class HarnessRunner:
         self.entrypoint_args = entrypoint_args or []
         self.agent_name = agent_name
         self.extra_env = extra_env or {}
+        self.timeout_sec = timeout_sec
 
         Path(self.output_path).mkdir(parents=True, exist_ok=True)
 
@@ -101,7 +104,7 @@ class HarnessRunner:
         self._current_task = task_id
         self._done = False
         self._passed = False
-        self._observation = "Task prepared. Provide a shell command if desired; the harness will run Terminus‑1 for the task on first step."
+        self._observation = "Task prepared. Provide a shell command if desired; the harness will run Terminus for the task on first step."
         return self._observation
 
     def _run_harness(self) -> tuple[bool, str]:
@@ -118,7 +121,7 @@ class HarnessRunner:
             }
             cfg_path.write_text(json.dumps(cfg), encoding="utf-8")
             cmd = [
-                shutil.which("python") or "python",
+                sys.executable,
                 "-m",
                 self.entrypoint_module,
                 "--config",
@@ -127,14 +130,23 @@ class HarnessRunner:
             ]
             env = os.environ.copy()
             env.update(self.extra_env)
-            proc = subprocess.run(
-                cmd,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                text=True,
-                env=env,
-            )
-            out = proc.stdout
+            try:
+                proc = subprocess.run(
+                    cmd,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                    env=env,
+                    timeout=self.timeout_sec,
+                )
+                out = proc.stdout
+                if proc.returncode != 0:
+                    tail = out[-2000:] if out else ""
+                    return False, f"TB harness exited with code {proc.returncode}.\n{tail}"
+            except subprocess.TimeoutExpired as e:
+                out = (e.stdout or "") + (e.stderr or "")
+                return False, f"TB harness timed out after {self.timeout_sec}s.\n{out[-2000:]}"
+
             # Attempt robust success detection across plausible report names
             resolved = False
             for name in ("final_report.json", "report.json", "results.json"):
@@ -166,5 +178,5 @@ class HarnessRunner:
         resolved, logs = self._run_harness()
         self._done = True
         self._passed = resolved
-        self._observation = ("All tests passed.\n" if resolved else "Tests failed.\n") + logs[-2000:]
-        return StepResult(self._observation, self._done, self._passed, {"task": self._current_task or "", "logs_tail": logs[-2000:]})
+        self._observation = ("All tests passed.\n" if resolved else "Tests failed.\n") + (logs[-2000:] if logs else "")
+        return StepResult(self._observation, self._done, self._passed, {"task": self._current_task or "", "logs_tail": (logs[-2000:] if logs else "")})


### PR DESCRIPTION
Hardening for harness runners

- Use `sys.executable` instead of `python`/PATH resolution to ensure the current venv/interpreter is used for `-m` module calls
- Add configurable timeouts (`timeout_sec`, default 1800s) and explicit return-code checks for all harness invocations; surface a helpful tail of combined stdout/stderr on failure or timeout
- Keep schema-aware result parsing (prefer `final_report.json`; fallback `report.json`/`results.json`) with instance-anchored checks
- Terminal-Bench: default agent renamed to `terminus` to align with public CLI docs; still configurable via `agent_name`

No behavior change to stub paths; official harness and OpenHands/TB harness runners remain optional and flag-gated.

If desired, I can add a short docs blurb mentioning the new defaults and the optional `timeout_sec` kwarg.