### PR TITLE
Loaders: fail-fast guards for TB/MSB harness paths + docs + tests

### DIFF
--- a/docs/multiswebench_integration.md
+++ b/docs/multiswebench_integration.md
@@ -47,3 +47,10 @@ Testing:
 | `OPENHANDS_ENTRYPOINT` | Yes (OpenHands) | Module path, e.g. `mopenhands.run` |
 
 Back‑compat aliases are preserved; the `openhands_entrypoint` takes precedence over `entrypoint_module`.
+
+Notes
+- When `use_openhands=true`, you must provide both `dataset_file` and
+  `OPENHANDS_ENTRYPOINT`. The environment loader fails fast with a clear error if
+  either is missing to prevent accidental fallbacks.
+- Both official and OpenHands runners enforce a default timeout of 1800s; for
+  programmatic use you can override `timeout_sec` on the runner.

--- a/docs/terminalbench_integration.md
+++ b/docs/terminalbench_integration.md
@@ -29,3 +29,9 @@ Testing:
 | `TB_DATASET_PATH` | Yes (harness) | Path to Terminal‑Bench tasks directory |
 | `TB_TASK_ID` | Yes | Task id |
 | `TB_ENTRYPOINT` | Yes (harness) | Harness entrypoint module (e.g., `terminal_bench.run`) |
+
+Notes
+- When `use_harness=true`, you must provide `dataset_path`. The loader fails fast
+  with a clear error if `use_harness=true` and `dataset_path` is missing.
+- The harness runner enforces a default timeout of 1800s; for programmatic use of
+  the runner class you can override `timeout_sec` if your hardware is slower.

--- a/environments/vf_multi_swe_bench/vf_multi_swe_bench.py
+++ b/environments/vf_multi_swe_bench/vf_multi_swe_bench.py
@@ -34,8 +34,21 @@ def load_environment(
     out = output_dir or "./msb_runs"
     inst_id = instance_id or task_id or "example-instance"
 
+    # Fail fast: if OpenHands path is requested, require dataset_file and entrypoint
+    if use_openhands:
+        if not dataset_file:
+            raise ValueError("use_openhands=True requires dataset_file to be provided")
+        if not openhands_entrypoint:
+            raise ValueError(
+                "use_openhands=True requires openhands_entrypoint (e.g., 'mopenhands.run')"
+            )
+
     if use_openhands and OpenHandsRunner and dataset_file:
-        runner = OpenHandsRunner(dataset_file=dataset_file, output_dir=out, openhands_entrypoint=openhands_entrypoint or "mopenhands.run")
+        runner = OpenHandsRunner(
+            dataset_file=dataset_file,
+            output_dir=out,
+            openhands_entrypoint=openhands_entrypoint,
+        )
     elif dataset_file and HarnessRunner:
         runner = HarnessRunner(dataset_file=dataset_file, output_dir=out)
     else:

--- a/environments/vf_terminal_bench/vf_terminal_bench.py
+++ b/environments/vf_terminal_bench/vf_terminal_bench.py
@@ -28,6 +28,10 @@ def load_environment(
         use_harness: Force using the harness when True, otherwise auto-detect based
             on dataset_path availability.
     """
+    # Fail fast: if harness is explicitly requested, require dataset_path
+    if use_harness and not dataset_path:
+        raise ValueError("use_harness=True requires dataset_path to be provided")
+
     if (use_harness or (use_harness is None and dataset_path)) and HarnessRunner:
         runner = HarnessRunner(  # type: ignore[call-arg]
             dataset_path=dataset_path,  # type: ignore[arg-type]

--- a/tests/test_loader_guards.py
+++ b/tests/test_loader_guards.py
@@ -1,0 +1,20 @@
+import pytest
+
+
+def test_tb_loader_requires_dataset_when_harness_forced():
+    import importlib
+    env_mod = importlib.import_module("environments.vf_terminal_bench.vf_terminal_bench")
+    with pytest.raises(ValueError):
+        env_mod.load_environment(task_id="stub", use_harness=True, dataset_path=None)
+
+
+def test_msb_loader_requires_dataset_and_entrypoint_when_openhands_forced():
+    import importlib
+    env_mod = importlib.import_module("environments.vf_multi_swe_bench.vf_multi_swe_bench")
+    # Missing dataset_file
+    with pytest.raises(ValueError):
+        env_mod.load_environment(instance_id="stub", use_openhands=True, dataset_file=None, openhands_entrypoint="mopenhands.run")
+    # Missing entrypoint
+    with pytest.raises(ValueError):
+        env_mod.load_environment(instance_id="stub", use_openhands=True, dataset_file="/tmp/dataset.jsonl", openhands_entrypoint=None)
+


### PR DESCRIPTION
Summary
- TB: Fail fast when `use_harness=True` but `dataset_path` is missing.
- MSB: Fail fast when `use_openhands=True` but `dataset_file` or `OPENHANDS_ENTRYPOINT` is missing.
- Docs: Add explicit notes about these requirements and mention default 1800s timeouts with override note for programmatic use.
- Tests: Add unit tests for the loader guards.

Rationale
- Removes subtle foot-guns and matches audit guidance for robust, explicit setup.
- Keeps behavior unchanged for valid harness runs and for stub defaults.

Scope
- Only touches example loaders, docs, and adds tests; no changes to core runner behavior or public APIs.
