### PR TITLE
Add BFCL v3/v4 environments and tests

### DIFF
--- a/docs/bfcl_integration.md
+++ b/docs/bfcl_integration.md
@@ -1,0 +1,37 @@
+BFCL Integration (v3 and v4)
+
+- v3 (multi-turn): BFCLV3Env (ToolEnv)
+  - Stateful tools; “Missing-Functions” gating reveals withheld tools mid-run.
+  - load programmatically:
+    - from verifiers.envs.bfcl_v3_env import load_environment
+    - env = load_environment(version="v3", mode="multi", dataset_file="path/to.jsonl")
+
+- v3 (single-turn): BFCLV3SingleTurnEnv (ToolEnv, max_turns=1)
+  - “Next-action” probes derived from v3 trajectories; binary reward (execution equivalence).
+  - Instantiate directly or via load_environment(..., mode="single").
+
+- v4 (multi-turn): BFCLV4WebEnv (ToolEnv)
+  - Tools: duckduckgo_search(keywords, max_results=10, region="wt-wt"); fetch_url_content(url, mode in {"raw","markdown","truncate"}).
+  - Seeded failure injection on fetch; optional offline cache for determinism.
+  - load programmatically:
+    - from verifiers.envs.bfcl_v4_env import load_environment
+    - env = load_environment(version="v4", mode="multi", offline_cache_dir="./cache", fetch_fail_rate=0.2, failure_seed=1234)
+
+- v4 (single-turn):
+  - BFCLV4SingleTurnEnv (B1): ToolEnv with max_turns=1.
+  - BFCLV4OracleSingleTurnEnv (B2): SingleTurnEnv with oracle evidence; no tools.
+
+- Rubrics:
+  - v4 uses BFCLV4Rubric (normalized exact-match on final JSON {"answer","context"}; grades only "answer").
+  - v3 rubrics attach externally; tests demonstrate binary execution success.
+
+Data loading
+- Read JSONL manually per BFCL instructions (do not call datasets.load_dataset).
+- Normalize to Dataset with prompt (messages), answer (v4), and info metadata.
+
+Parallel tool calls
+- ToolEnv supports multiple tool calls in a single assistant message (v4 single-turn B1).
+
+Reproducibility
+- v4: set failure_seed and offline_cache_dir; offline=True when cache dir provided and no network.
+- v3: reset internal state per rollout.

--- a/tests/test_bfcl_v3_env.py
+++ b/tests/test_bfcl_v3_env.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import json
+
+from datasets import Dataset
+
+from verifiers.envs.bfcl_v3_env import BFCLV3Env, BFCLV3SingleTurnEnv
+
+
+def test_v3_missing_functions_gating_reveals_tool_and_injects_doc():
+    ds = Dataset.from_dict({"prompt": [[{"role": "user", "content": "start"}]], "info": [{}]})
+    env = BFCLV3Env(dataset=ds, enable_missing_functions=True)
+    # Assistant indicates the need for missing function (no tool_calls)
+    assistant_msg = [{"role": "assistant", "content": "I need a missing function to proceed."}]
+    env_msgs, _ = env.env_response(assistant_msg, {"turn": 1})
+    assert any(m["role"] == "user" and "New tool unlocked" in m["content"] for m in env_msgs)
+    assert "secret_add" in env.tool_map
+    # Issue the tool call now that it's revealed
+    tool_msg = env.call_tool("secret_add", json.dumps({"x": 2, "y": 3}), "c1")
+    assert tool_msg["role"] == "tool" and tool_msg["content"] == "5"
+
+
+def test_v3_single_turn_next_action_env_builds_and_executes():
+    ds = Dataset.from_dict(
+        {
+            "prompt": [[{"role": "user", "content": "set key=foo to bar"}]],
+            "info": [{"expected": {"tool": "set_kv", "args": {"key": "foo", "value": "bar"}, "output": "OK"}}],
+        }
+    )
+    env = BFCLV3SingleTurnEnv(dataset=ds)
+    assert env.max_turns == 1
+    tool_msg = env.call_tool("set_kv", json.dumps({"key": "foo", "value": "bar"}), "c1")
+    assert tool_msg["role"] == "tool" and tool_msg["content"] == "OK"

--- a/tests/test_bfcl_v4_env.py
+++ b/tests/test_bfcl_v4_env.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+
+from datasets import Dataset
+
+from verifiers.envs.bfcl_v4_env import (
+    BFCLV4WebEnv,
+    BFCLV4SingleTurnEnv,
+    BFCLV4OracleSingleTurnEnv,
+    answer_exact_match,
+)
+
+
+def test_v4_tools_failure_injection_deterministic(tmp_path):
+    ds = Dataset.from_dict(
+        {"prompt": [[{"role": "user", "content": "q"}]], "answer": [""], "info": [{}]}
+    )
+    env = BFCLV4WebEnv(
+        dataset=ds,
+        include_snippets=True,
+        fetch_fail_rate=1.0,  # always fail
+        failure_seed=42,
+        offline_cache_dir=str(tmp_path),
+        max_turns=2,
+    )
+    # Directly exercise tool call
+    tool_msg = env.call_tool("fetch_url_content", json.dumps({"url": "https://x", "mode": "raw"}), "c1")
+    assert tool_msg["role"] == "tool"
+    assert isinstance(tool_msg["content"], str) and tool_msg["content"].startswith("ERROR:")
+
+
+def test_v4_answer_exact_match_normalization():
+    gold = "Hello, World."
+    completion = [{"role": "assistant", "content": json.dumps({"answer": "hello world", "context": "x"})}]
+    score = answer_exact_match(prompt=[{"role": "user", "content": "q"}], completion=completion, answer=gold)
+    assert score == 1.0
+    completion_bad = [{"role": "assistant", "content": '{"foo":"bar"}'}]
+    assert answer_exact_match([{"role": "user", "content": "q"}], completion_bad, gold) == 0.0
+
+
+def test_v4_single_turn_variants_construct():
+    ds = Dataset.from_dict(
+        {"prompt": [[{"role": "user", "content": "q"}]], "answer": [""], "info": [{}]}
+    )
+    env1 = BFCLV4SingleTurnEnv(dataset=ds, fetch_fail_rate=0.0)
+    assert env1.max_turns == 1
+    env2 = BFCLV4OracleSingleTurnEnv(dataset=ds)
+    assert env2.max_turns == 10  # SingleTurnEnv default

--- a/verifiers/envs/bfcl_v3_env.py
+++ b/verifiers/envs/bfcl_v3_env.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Literal, Optional
+
+from datasets import Dataset
+
+from verifiers import ToolEnv, SingleTurnEnv, Rubric, Parser
+from verifiers.types import Messages, State
+
+
+@dataclass
+class V3Config:
+    max_turns: int = 8
+    withheld_tool_doc: str = (
+        "New tool unlocked: secret_add(x: int, y: int) -> int. "
+        "Use to add two integers when required."
+    )
+
+
+def _read_jsonl(path: str | Path) -> list[dict]:
+    items: list[dict] = []
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            items.append(json.loads(line))
+    return items
+
+
+def _to_dataset_v3(items: list[dict]) -> Dataset:
+    prompts: list[list[dict]] = []
+    infos: list[dict] = []
+    for it in items:
+        if "prompt" in it:
+            prompts.append(it["prompt"])
+        else:
+            q = it.get("question") or it.get("query") or ""
+            prompts.append([{"role": "user", "content": q}])
+        info = dict(it.get("info", {}))
+        if "expected" in it:
+            info["expected"] = it["expected"]
+        infos.append(info)
+    return Dataset.from_dict({"prompt": prompts, "info": infos})
+
+
+def _mk_v3_tools(statebox: dict[str, Any]) -> list[Callable]:
+    def set_kv(key: str, value: str) -> str:
+        """Set a string value in the environment state.
+
+        Args:
+            key (str): The key to set.
+            value (str): The string value.
+        """
+        statebox.setdefault("kv", {})[key] = value
+        return "OK"
+
+    def get_kv(key: str) -> str:
+        """Get a string value from the environment state.
+
+        Args:
+            key (str): The key to read.
+        """
+        return str(statebox.get("kv", {}).get(key, ""))
+
+    def secret_add(x: int, y: int) -> int:
+        """Add two integers (withheld initially in Missing-Functions scenarios).
+
+        Args:
+            x (int): first operand
+            y (int): second operand
+        """
+        return x + y
+
+    return [set_kv, get_kv, secret_add]
+
+
+class BFCLV3Env(ToolEnv):
+    """BFCL v3 multi-turn ToolEnv with missing-function gating."""
+
+    def __init__(
+        self,
+        dataset: Dataset | None = None,
+        eval_dataset: Dataset | None = None,
+        max_turns: int = 8,
+        enable_missing_functions: bool = True,
+        **kwargs: Any,
+    ):
+        self._statebox: dict[str, Any] = {}
+        all_tools = _mk_v3_tools(self._statebox)
+        self._withheld_name = "secret_add"
+        self._withheld_tool = next(t for t in all_tools if t.__name__ == self._withheld_name)
+        start_tools = [t for t in all_tools if t.__name__ != self._withheld_name] if enable_missing_functions else all_tools
+        self._enable_missing = enable_missing_functions
+        self._revealed = False
+        self._reveal_doc = V3Config().withheld_tool_doc
+        super().__init__(
+            tools=start_tools,
+            max_turns=max_turns,
+            dataset=dataset,
+            eval_dataset=eval_dataset,
+            parser=Parser(),
+            rubric=Rubric(),
+            **kwargs,
+        )
+
+    def setup_state(self, state: State, **kwargs) -> State:
+        state["tool_stage"] = 0
+        return state
+
+    def _should_reveal(self, messages: Messages) -> bool:
+        if not isinstance(messages, list) or not messages:
+            return False
+        last = messages[-1]
+        if last.get("role") == "assistant" and isinstance(last.get("content"), str):
+            txt = last["content"].lower()
+            return "missing function" in txt or "reveal tool" in txt
+        return False
+
+    def _expose_withheld(self):
+        if self._revealed:
+            return
+        self.tools.append(self._withheld_tool)
+        # Rebuild mapping/schema for execution on next turn
+        self.tool_map[self._withheld_name] = self._withheld_tool
+        self._revealed = True
+
+    def env_response(self, messages: Messages, state: State, **kwargs) -> tuple[Messages, State]:
+        # If the assistant called tools, run ToolEnv's handling first
+        tool_msgs: list[dict] = []
+        if isinstance(messages, list) and messages and "tool_calls" in messages[-1]:
+            tool_msgs, state = super().env_response(messages, state, **kwargs)
+
+        extra: list[dict] = []
+        if self._enable_missing and not self._revealed and self._should_reveal(messages):
+            self._expose_withheld()
+            extra.append({"role": "user", "content": self._reveal_doc})
+            state["tool_stage"] = 1
+
+        return tool_msgs + extra, state
+
+
+class BFCLV3SingleTurnEnv(ToolEnv):
+    """Single-turn 'next-action' probe built from v3 trajectories."""
+
+    def __init__(
+        self,
+        dataset: Dataset | None = None,
+        eval_dataset: Dataset | None = None,
+        **kwargs: Any,
+    ):
+        self._statebox: dict[str, Any] = {}
+        tools = _mk_v3_tools(self._statebox)
+        super().__init__(
+            tools=tools,
+            max_turns=1,
+            dataset=dataset,
+            eval_dataset=eval_dataset,
+            parser=Parser(),
+            rubric=Rubric(),
+            **kwargs,
+        )
+
+
+def load_environment(
+    version: Literal["v3"] = "v3",
+    mode: Literal["multi", "single"] = "multi",
+    dataset_file: str | None = None,
+    **kwargs: Any,
+):
+    ds = None
+    if dataset_file:
+        items = _read_jsonl(dataset_file)
+        ds = _to_dataset_v3(items)
+    if mode == "multi":
+        return BFCLV3Env(dataset=ds, **kwargs)
+    if mode == "single":
+        return BFCLV3SingleTurnEnv(dataset=ds, **kwargs)
+    raise ValueError(f"Unsupported v3 mode: {mode}")

--- a/verifiers/envs/bfcl_v4_env.py
+++ b/verifiers/envs/bfcl_v4_env.py
@@ -1,0 +1,281 @@
+from __future__ import annotations
+
+import json
+import random
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Literal, Optional
+
+from datasets import Dataset
+
+from verifiers import ToolEnv, SingleTurnEnv, Rubric, Parser
+from verifiers.types import Messages
+
+
+@dataclass
+class V4Config:
+    include_snippets: bool = True
+    fetch_fail_rate: float = 0.0
+    failure_seed: int = 1234
+    offline_cache_dir: Optional[str] = None
+    max_turns: int = 8
+
+
+def _read_jsonl(path: str | Path) -> list[dict]:
+    items: list[dict] = []
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            items.append(json.loads(line))
+    return items
+
+
+def _to_dataset_v4(items: list[dict]) -> Dataset:
+    prompts: list[list[dict]] = []
+    answers: list[str] = []
+    infos: list[dict] = []
+    for it in items:
+        if "prompt" in it:
+            prompts.append(it["prompt"])
+        else:
+            q = it.get("question") or ""
+            prompts.append([{"role": "user", "content": q}])
+        answers.append(it.get("answer", ""))
+        info = dict(it.get("info", {}))
+        if "sources" in it:
+            info["sources"] = it["sources"]
+        if "gold_urls" in it:
+            info["gold_urls"] = it["gold_urls"]
+        infos.append(info)
+    return Dataset.from_dict({"prompt": prompts, "answer": answers, "info": infos})
+
+
+def _normalize_answer(s: str) -> str:
+    s = s.lower()
+    s = re.sub(r"[\,\.\/\-\_\*\^\(\)]", "", s)
+    s = s.strip()
+    return s
+
+
+def answer_exact_match(prompt: Messages, completion: Messages, answer: str, **kwargs) -> float:
+    if not isinstance(completion, list) or not completion:
+        return 0.0
+    last = completion[-1]
+    content = last.get("content", "")
+    try:
+        obj = json.loads(content) if isinstance(content, str) else {}
+    except Exception:
+        return 0.0
+    if not isinstance(obj, dict) or "answer" not in obj:
+        return 0.0
+    pred = _normalize_answer(str(obj.get("answer", "")))
+    gold = _normalize_answer(str(answer))
+    return 1.0 if pred == gold else 0.0
+
+
+class BFCLV4Rubric(Rubric):
+    def __init__(self):
+        super().__init__(funcs=[answer_exact_match], weights=[1.0], parser=Parser())
+
+
+class _Cache:
+    def __init__(self, root: Optional[str]):
+        self.root = Path(root) if root else None
+        if self.root:
+            self.root.mkdir(parents=True, exist_ok=True)
+
+    def _p(self, name: str) -> Optional[Path]:
+        if not self.root:
+            return None
+        return self.root / name
+
+    def get_json(self, name: str) -> Optional[Any]:
+        p = self._p(name)
+        if not p or not p.exists():
+            return None
+        try:
+            return json.loads(p.read_text(encoding="utf-8"))
+        except Exception:
+            return None
+
+    def put_json(self, name: str, obj: Any) -> None:
+        p = self._p(name)
+        if not p:
+            return
+        p.write_text(json.dumps(obj), encoding="utf-8")
+
+    def get_text(self, name: str) -> Optional[str]:
+        p = self._p(name)
+        if not p or not p.exists():
+            return None
+        try:
+            return p.read_text(encoding="utf-8")
+        except Exception:
+            return None
+
+    def put_text(self, name: str, s: str) -> None:
+        p = self._p(name)
+        if not p:
+            return
+        p.write_text(s, encoding="utf-8")
+
+
+def _mk_v4_tools(cfg: V4Config) -> list[Callable]:
+    cache = _Cache(cfg.offline_cache_dir)
+    rng = random.Random(cfg.failure_seed)
+
+    def duckduckgo_search(keywords: str, max_results: int = 10, region: str = "wt-wt") -> list[dict]:
+        """Return [{'title': str, 'url': str, 'snippet'?: str}]"""
+        key = f"search::{region}::{max_results}::{keywords}"
+        if cache.root:
+            obj = cache.get_json(key)
+            if obj is not None:
+                return obj
+            if cfg.offline_cache_dir is not None:
+                return []
+        result = [{"title": f"About {keywords}", "url": f"https://example.com/{keywords.replace(' ', '_')}"}]
+        if cfg.include_snippets:
+            result[0]["snippet"] = f"Snippet for {keywords}"
+        if cache.root:
+            cache.put_json(key, result)
+        return result[:max_results]
+
+    def fetch_url_content(url: str, mode: Literal["raw", "markdown", "truncate"] = "raw") -> str:
+        """Return page content; simulate failures via seeded RNG; cache results."""
+        key = f"page::{mode}::{url}"
+        if cfg.fetch_fail_rate > 0:
+            u = rng.random()
+            if u < cfg.fetch_fail_rate:
+                failures = [
+                    "ERROR: 503 Service Unavailable",
+                    "ERROR: 429 Too Many Requests",
+                    "ERROR: 403 Forbidden",
+                    "ERROR: ConnectTimeout",
+                    "ERROR: ReadTimeout",
+                    "ERROR: ConnectionError",
+                ]
+                return failures[int(u * len(failures)) % len(failures)]
+        if cache.root:
+            txt = cache.get_text(key)
+            if txt is not None:
+                return txt
+            if cfg.offline_cache_dir is not None:
+                return ""
+        body = f"Content fetched from {url}\n"
+        if mode == "markdown":
+            body = f"# {url}\n\n{body}"
+        elif mode == "truncate":
+            body = body[:32]
+        if cache.root:
+            cache.put_text(key, body)
+        return body
+
+    return [duckduckgo_search, fetch_url_content]
+
+
+class BFCLV4WebEnv(ToolEnv):
+    """Multi-turn web-search ToolEnv with exact tool signatures and failure injection."""
+
+    def __init__(
+        self,
+        dataset: Dataset | None = None,
+        eval_dataset: Dataset | None = None,
+        include_snippets: bool = True,
+        fetch_fail_rate: float = 0.0,
+        failure_seed: int = 1234,
+        offline_cache_dir: Optional[str] = None,
+        max_turns: int = 8,
+        **kwargs: Any,
+    ):
+        cfg = V4Config(
+            include_snippets=include_snippets,
+            fetch_fail_rate=fetch_fail_rate,
+            failure_seed=failure_seed,
+            offline_cache_dir=offline_cache_dir,
+            max_turns=max_turns,
+        )
+        tools = _mk_v4_tools(cfg)
+        super().__init__(
+            tools=tools,
+            max_turns=max_turns,
+            dataset=dataset,
+            eval_dataset=eval_dataset,
+            parser=Parser(),
+            rubric=BFCLV4Rubric(),
+            **kwargs,
+        )
+
+
+class BFCLV4SingleTurnEnv(ToolEnv):
+    """Single-turn (B1): ToolEnv with max_turns=1; parallel tool calls allowed."""
+
+    def __init__(
+        self,
+        dataset: Dataset | None = None,
+        eval_dataset: Dataset | None = None,
+        include_snippets: bool = True,
+        fetch_fail_rate: float = 0.0,
+        failure_seed: int = 1234,
+        offline_cache_dir: Optional[str] = None,
+        **kwargs: Any,
+    ):
+        cfg = V4Config(
+            include_snippets=include_snippets,
+            fetch_fail_rate=fetch_fail_rate,
+            failure_seed=failure_seed,
+            offline_cache_dir=offline_cache_dir,
+            max_turns=1,
+        )
+        tools = _mk_v4_tools(cfg)
+        super().__init__(
+            tools=tools,
+            max_turns=1,
+            dataset=dataset,
+            eval_dataset=eval_dataset,
+            parser=Parser(),
+            rubric=BFCLV4Rubric(),
+            **kwargs,
+        )
+
+
+class BFCLV4OracleSingleTurnEnv(SingleTurnEnv):
+    """Single-turn (B2): oracle evidence; no tools."""
+
+    def __init__(
+        self,
+        dataset: Dataset | None = None,
+        eval_dataset: Dataset | None = None,
+        **kwargs: Any,
+    ):
+        super().__init__(
+            dataset=dataset,
+            eval_dataset=eval_dataset,
+            parser=Parser(),
+            rubric=BFCLV4Rubric(),
+            **kwargs,
+        )
+
+
+def load_environment(
+    version: Literal["v4"] = "v4",
+    mode: Literal["multi", "single"] = "multi",
+    single_turn_variant: Literal["b1", "b2"] = "b1",
+    dataset_file: str | None = None,
+    **kwargs: Any,
+):
+    ds = None
+    if dataset_file:
+        items = _read_jsonl(dataset_file)
+        ds = _to_dataset_v4(items)
+    if mode == "multi":
+        return BFCLV4WebEnv(dataset=ds, **kwargs)
+    if mode == "single":
+        if single_turn_variant == "b1":
+            return BFCLV4SingleTurnEnv(dataset=ds, **kwargs)
+        if single_turn_variant == "b2":
+            return BFCLV4OracleSingleTurnEnv(dataset=ds, **kwargs)
+        raise ValueError(f"Unsupported v4 single_turn_variant: {single_turn_variant}")
+    raise ValueError(f"Unsupported v4 mode: {mode}")


### PR DESCRIPTION
This PR adds BFCL v3 and v4 environments with both multi-turn and single-turn modes, aligning with the reconciled plan from the two audits.

Highlights
- v3: Multi-turn ToolEnv with missing-function gating that both injects a user reveal message and enables withheld tools in the next turn. Single-turn next-action ToolEnv (max_turns=1).
- v4: Web-search ToolEnv with exact tool signatures (duckduckgo_search, fetch_url_content), seeded failure injection returning canonical error strings, offline cache, and a rubric that scores normalized EM on the final JSON 'answer' only. Single-turn B1 (ToolEnv max_turns=1) and B2 (oracle evidence SingleTurnEnv) variants.
- JSONL ingestion done manually; no datasets.load_dataset usage. Deterministic offline options via failure_seed and offline_cache_dir.
- Tests for v3 gating/next-action and v4 failure injection/EM normalization + single-turn wrappers.
- Docs: docs/bfcl_integration.md for usage.

Co-authored-by: Spencer Garnets <spencer@whyphy.ai>