### PR TITLE
BFCL follow-ups: v4 oracle injection, v3 minimal rubrics, loader/rubric tests

### DIFF
--- a/tests/test_bfcl_v3_rubrics.py
+++ b/tests/test_bfcl_v3_rubrics.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from verifiers.envs.bfcl_v3_env import BFCLV3SingleTurnRubric
+
+
+def test_v3_single_turn_rubric_matches_output_when_present():
+    rubric = BFCLV3SingleTurnRubric()
+    info = {"expected": {"tool": "set_kv", "args": {"key": "k", "value": "v"}, "output": "OK"}}
+    completion = [
+        {"role": "assistant", "content": ""},
+        {"role": "tool", "content": "OK", "tool_call_id": "t1"},
+    ]
+    score = rubric.get_reward_funcs()[0](parser=None, prompt=[], completion=completion, answer="", state={}, task="default", info=info)
+    assert score == 1.0

--- a/tests/test_bfcl_v4_loader_and_rubric.py
+++ b/tests/test_bfcl_v4_loader_and_rubric.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import json
+
+from datasets import Dataset
+
+from verifiers.envs.bfcl_v4_env import BFCLV4Rubric, load_environment as load_v4
+
+
+def test_v4_loader_single_and_multi_constructs():
+    ds = Dataset.from_dict({"prompt": [[{"role": "user", "content": "q"}]], "answer": ["42"], "info": [{}]})
+    env_single = load_v4(version="v4", mode="single", single_turn_variant="b1", dataset=ds)
+    env_multi = load_v4(version="v4", mode="multi", dataset=ds)
+    assert env_single.max_turns == 1
+    assert env_multi.max_turns > 1
+
+
+def test_v4_rubric_class_scores_exact_match():
+    rubric = BFCLV4Rubric()
+    prompt = [{"role": "user", "content": "q"}]
+    completion = [{"role": "assistant", "content": json.dumps({"answer": "hello world", "context": "x"})}]
+    gold = "Hello, World."
+    score = rubric.get_reward_funcs()[0](parser=None, prompt=prompt, completion=completion, answer=gold, state={}, task="default", info={})
+    assert score == 1.0

--- a/tests/test_bfcl_v4_oracle_injection.py
+++ b/tests/test_bfcl_v4_oracle_injection.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from datasets import Dataset
+
+from verifiers.envs.bfcl_v4_env import BFCLV4OracleSingleTurnEnv
+
+
+def test_v4_oracle_injection_into_prompt():
+    ds = Dataset.from_dict({
+        "prompt": [[{"role": "user", "content": "answer the question"}]],
+        "answer": ["foo"],
+        "info": [{"evidence": "This is the gold evidence."}],
+    })
+    env = BFCLV4OracleSingleTurnEnv(dataset=ds)
+    injected = env.dataset[0]["prompt"][0]["content"]
+    assert "gold evidence" in injected.lower()

--- a/verifiers/envs/bfcl_v3_env.py
+++ b/verifiers/envs/bfcl_v3_env.py
@@ -128,14 +128,12 @@ class BFCLV3Env(ToolEnv):
         return False
 
     def _should_reveal_by_attempt(self, messages: Messages) -> bool:
-        # If assistant tried to call the withheld tool before reveal
         if not isinstance(messages, list) or not messages:
             return False
         last = messages[-1]
         tcs = last.get("tool_calls") if isinstance(last, dict) else None
         if not tcs:
             return False
-        # Accept both dict-like and object-like with .function
         for tc in tcs:
             try:
                 name = tc["function"]["name"] if isinstance(tc, dict) else tc.function.name
@@ -154,7 +152,6 @@ class BFCLV3Env(ToolEnv):
 
     def env_response(self, messages: Messages, state: State, **kwargs) -> tuple[Messages, State]:
         extra: list[dict] = []
-        # If model attempted the withheld tool, reveal it and inject docs; skip executing tools this turn
         if self._enable_missing and not self._revealed and self._should_reveal_by_attempt(messages):
             self._expose_withheld()
             extra.append({"role": "user", "content": self._reveal_doc})
@@ -195,13 +192,35 @@ class BFCLV3SingleTurnEnv(ToolEnv):
         )
 
 
+# Minimal rubrics for v3
+
+def _single_turn_exec_match(prompt: Messages, completion: Messages, answer: str, state: dict, info: dict, **kwargs) -> float:
+    """If info.expected.output is present, match last tool message content against it; else 0."""
+    exp = (info or {}).get("expected", {})
+    want = exp.get("output")
+    if not want:
+        return 0.0
+    if isinstance(completion, list):
+        # find last tool message
+        for m in reversed(completion):
+            if isinstance(m, dict) and m.get("role") == "tool":
+                return 1.0 if str(m.get("content", "")) == str(want) else 0.0
+    return 0.0
+
+
+class BFCLV3SingleTurnRubric(Rubric):
+    def __init__(self):
+        super().__init__(funcs=[_single_turn_exec_match], weights=[1.0], parser=Parser())
+
+
 def load_environment(
     version: Literal["v3"] = "v3",
     mode: Literal["multi", "single"] = "multi",
     dataset_file: str | None = None,
+    dataset: Dataset | None = None,
     **kwargs: Any,
 ):
-    ds = None
+    ds = dataset
     if dataset_file:
         items = _read_jsonl(dataset_file)
         ds = _to_dataset_v3(items)

--- a/verifiers/envs/bfcl_v4_env.py
+++ b/verifiers/envs/bfcl_v4_env.py
@@ -49,6 +49,9 @@ def _to_dataset_v4(items: list[dict]) -> Dataset:
             info["sources"] = it["sources"]
         if "gold_urls" in it:
             info["gold_urls"] = it["gold_urls"]
+        # optional oracle evidence
+        if "evidence" in it:
+            info["evidence"] = it["evidence"]
         infos.append(info)
     return Dataset.from_dict({"prompt": prompts, "answer": answers, "info": infos})
 
@@ -241,6 +244,21 @@ class BFCLV4SingleTurnEnv(ToolEnv):
         )
 
 
+def _inject_oracle(ds: Dataset) -> Dataset:
+    # Prepend a system message with evidence when present
+    def add_evidence(prompt: list[dict], info: dict) -> list[dict]:
+        ev = info.get("evidence")
+        if not ev:
+            return prompt
+        sys_msg = {"role": "system", "content": f"### Evidence (oracle)\n{ev}"}
+        return [sys_msg] + prompt
+
+    prompts = []
+    for i in range(len(ds)):
+        prompts.append(add_evidence(ds[i]["prompt"], ds[i]["info"]))
+    return Dataset.from_dict({"prompt": prompts, "answer": ds["answer"], "info": ds["info"]})
+
+
 class BFCLV4OracleSingleTurnEnv(SingleTurnEnv):
     """Single-turn (B2): oracle evidence; no tools."""
 
@@ -248,8 +266,11 @@ class BFCLV4OracleSingleTurnEnv(SingleTurnEnv):
         self,
         dataset: Dataset | None = None,
         eval_dataset: Dataset | None = None,
+        inject_oracle: bool = True,
         **kwargs: Any,
     ):
+        if dataset is not None and inject_oracle:
+            dataset = _inject_oracle(dataset)
         super().__init__(
             dataset=dataset,
             eval_dataset=eval_dataset,
@@ -265,9 +286,10 @@ def load_environment(
     mode: Literal["multi", "single"] = "multi",
     single_turn_variant: Literal["b1", "b2"] = "b1",
     dataset_file: str | None = None,
+    dataset: Dataset | None = None,
     **kwargs: Any,
 ):
-    ds = None
+    ds = dataset
     if dataset_file:
         items = _read_jsonl(dataset_file)
         ds = _to_dataset_v4(items)


### PR DESCRIPTION
This PR addresses additional items from the latest BFCL audits:

- v4 Oracle (B2): injects oracle evidence (when provided in info.evidence) as a leading system message; keeps no-tools constraint; max_turns=1.
- v4 loader/rubric tests: smoke test for load_environment single/multi; unit test for BFCLV4Rubric exact-match scoring.
- v3 minimal rubrics: adds BFCLV3SingleTurnRubric that checks execution-equivalence via expected.output vs last tool message; foundation for fuller state/trajectory checks.
- v4 Oracle injection test: validates evidence injection path.

Note: Live-web mode and full v3 multi-turn state/trajectory rubrics are out-of-scope for this step and can follow as separate PRs. This PR focuses on correctness and audit-driven coverage gaps.

Co-authored-by: Spencer Garnets <spencer@whyphy.ai>